### PR TITLE
Fixing circleci after goig back to using GOOGLE_APPLICATION_CREDENTIALS to store value and not path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,13 @@ jobs: # A basic unit of work in a run
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
     steps: # steps that comprise the `build` job
-      - run: GIT_SECRET_PRIVATE=$(echo $GIT_SECRET_PRIVATE | base64 -d)
+      - run: GIT_SECRET_PRIVATE_LOCAL=$(echo $GIT_SECRET_PRIVATE | base64 -d)
       - checkout # check out source code to working directory
       - run: sudo apt-get update && sudo apt-get install apt-transport-https
       - run: echo "deb https://dl.bintray.com/sobolevn/deb git-secret main" | sudo tee -a /etc/apt/sources.list
       - run: wget -qO - https://api.bintray.com/users/sobolevn/keys/gpg/public.key | sudo apt-key add -
       - run: sudo apt-get update && sudo apt-get install git-secret
-      - run: echo -e "$GIT_SECRET_PRIVATE" | gpg --import
+      - run: echo -e "$GIT_SECRET_PRIVATE_LOCAL" | gpg --import
       - run: git secret tell inur@circleci.com
       - run: git secret reveal -f
       - run: sudo chown -R circleci:circleci /usr/local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs: # A basic unit of work in a run
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
     steps: # steps that comprise the `build` job
-      - run: GIT_SECRET_PRIVATE=$(echo $MY_ENCODED_VALUE | base64 -d)
+      - run: GIT_SECRET_PRIVATE=$(echo $GIT_SECRET_PRIVATE | base64 -d)
       - checkout # check out source code to working directory
       - run: sudo apt-get update && sudo apt-get install apt-transport-https
       - run: echo "deb https://dl.bintray.com/sobolevn/deb git-secret main" | sudo tee -a /etc/apt/sources.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,7 @@ jobs: # A basic unit of work in a run
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
     steps: # steps that comprise the `build` job
-      - run:
-          command: |
-            echo "git secret here"
-            echo $GIT_SECRET_PRIVATE
-            echo $GIT_SECRET_PRIVATE >~/private_key.gpg
-            cat ~/private_key.gpg
+      - run: GIT_SECRET_PRIVATE=$(echo $MY_ENCODED_VALUE | base64 -d)
       - checkout # check out source code to working directory
       - run: sudo apt-get update && sudo apt-get install apt-transport-https
       - run: echo "deb https://dl.bintray.com/sobolevn/deb git-secret main" | sudo tee -a /etc/apt/sources.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,7 @@ jobs: # A basic unit of work in a run
             - "/usr/local/lib/python3.6/site-packages"
       - run:
           command: |
-            echo GOOGLE_APPLICATION_CREDENTIALS=$(cat .gitsecret/inuropefitoo-81423d9d316b.json)>.env
-            cat  .env
+            cp .gitsecret/inuropefitoo-81423d9d316b.json ./keys/gdrive_storage_key.json
             pipenv run python manage.py test
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs: # A basic unit of work in a run
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
     steps: # steps that comprise the `build` job
-      - run: GIT_SECRET_PRIVATE_LOCAL=$(echo $GIT_SECRET_PRIVATE | base64 -d)
       - checkout # check out source code to working directory
       - run: sudo apt-get update && sudo apt-get install apt-transport-https
       - run: echo "deb https://dl.bintray.com/sobolevn/deb git-secret main" | sudo tee -a /etc/apt/sources.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs: # A basic unit of work in a run
       - run: echo "deb https://dl.bintray.com/sobolevn/deb git-secret main" | sudo tee -a /etc/apt/sources.list
       - run: wget -qO - https://api.bintray.com/users/sobolevn/keys/gpg/public.key | sudo apt-key add -
       - run: sudo apt-get update && sudo apt-get install git-secret
-      - run: echo -e "$GIT_SECRET_PRIVATE_LOCAL" | gpg --import
+      - run: echo -e "$GIT_SECRET_PRIVATE" | gpg --import
       - run: git secret tell inur@circleci.com
       - run: git secret reveal -f
       - run: sudo chown -R circleci:circleci /usr/local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs: # A basic unit of work in a run
             - "/usr/local/lib/python3.6/site-packages"
       - run:
           command: |
-            GOOGLE_APPLICATION_CREDENTIALS=$(cat .gitsecret/inuropefitoo-81423d9d316b.json)
-            echo GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS>.env
+            echo GOOGLE_APPLICATION_CREDENTIALS=$(cat .gitsecret/inuropefitoo-81423d9d316b.json)>.env
+            cat  .env
             pipenv run python manage.py test
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs: # A basic unit of work in a run
             - "/usr/local/lib/python3.6/site-packages"
       - run:
           command: |
-            echo GOOGLE_APPLICATION_CREDENTIALS=.gitsecret/inuropefitoo-81423d9d316b.json>.env
+            GOOGLE_APPLICATION_CREDENTIALS=$(cat .gitsecret/inuropefitoo-81423d9d316b.json)
+            echo GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS>.env
             pipenv run python manage.py test
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test-results

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ var/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+Pipfile
+
 
 # Installer logs
 pip-log.txt

--- a/invoices/settings.py
+++ b/invoices/settings.py
@@ -90,7 +90,7 @@ WSGI_APPLICATION = 'invoices.wsgi.application'
 import dj_database_url
 
 DATABASES = {'default': dj_database_url.config(default='postgres://inur:inur@localhost:5432/inur')}
-if 'test' in os.sys.argv:
+if 'CIRCLECI' in os.sys.argv:
     DATABASES['default'] = dj_database_url.config(default='postgresql://root@localhost/circle_test?sslmode=disable')
 
 # Enable Connection Pooling

--- a/invoices/settings.py
+++ b/invoices/settings.py
@@ -211,6 +211,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
 GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE = os.path.join(BASE_DIR, '../keys/gdrive_storage_key.json')
 if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ and not os.path.exists(GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE):
     credentials = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
+    print(credentials)
     with open(GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE, 'w') as outfile:
         json.dump(json.loads(credentials), outfile)
 

--- a/invoices/settings.py
+++ b/invoices/settings.py
@@ -211,7 +211,6 @@ CONSTANCE_CONFIG_FIELDSETS = {
 GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE = os.path.join(BASE_DIR, '../keys/gdrive_storage_key.json')
 if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ and not os.path.exists(GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE):
     credentials = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
-    print(credentials)
     with open(GOOGLE_DRIVE_STORAGE_JSON_KEY_FILE, 'w') as outfile:
         json.dump(json.loads(credentials), outfile)
 


### PR DESCRIPTION
I have Shortcutted the GOOGLE_APPLICATION_CREDENTIALS variable, I had alraedy the json key file encrypted with git secret, so I just copy it to "keys" folder.

Added Pipfile to .gitignore because localtest with circleci or pipenv generated it in my repo

 I thought you already changed <if 'test' in os.sys.argv:> to <if 'CIRCLECI' in os.sys.argv:>! anyways it is here now 